### PR TITLE
build:Fix set-env warning

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -159,11 +159,11 @@ jobs:
           test -d "$CACHE_DIR_DL" || mkdir -p "$CACHE_DIR_DL"
           test -d "$CACHE_DIR_FEEDS" || mkdir -p "$CACHE_DIR_FEEDS"
 
-          echo "::set-env name=CACHE_DIR_SDK::$CACHE_DIR_SDK"
-          echo "::set-env name=CACHE_DIR_DL::$CACHE_DIR_DL"
-          echo "::set-env name=CACHE_DIR_FEEDS::$CACHE_DIR_FEEDS"
+          echo "CACHE_DIR_SDK=$CACHE_DIR_SDK" >> $GITHUB_ENV
+          echo "CACHE_DIR_DL=$CACHE_DIR_DL" >> $GITHUB_ENV
+          echo "CACHE_DIR_FEEDS=$CACHE_DIR_FEEDS" >> $GITHUB_ENV
 
-          echo "::set-env name=SDK_HOME::$(mktemp -d)"
+          echo "SDK_HOME=$(mktemp -d)" >> $GITHUB_ENV
 
       - name: Download and Unzip SDK
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,11 +58,11 @@ jobs:
           test -d "$CACHE_DIR_DL" || mkdir -p "$CACHE_DIR_DL"
           test -d "$CACHE_DIR_FEEDS" || mkdir -p "$CACHE_DIR_FEEDS"
 
-          echo "::set-env name=CACHE_DIR_SDK::$CACHE_DIR_SDK"
-          echo "::set-env name=CACHE_DIR_DL::$CACHE_DIR_DL"
-          echo "::set-env name=CACHE_DIR_FEEDS::$CACHE_DIR_FEEDS"
+          echo "CACHE_DIR_SDK=$CACHE_DIR_SDK" >> $GITHUB_ENV
+          echo "CACHE_DIR_DL=$CACHE_DIR_DL" >> $GITHUB_ENV
+          echo "CACHE_DIR_FEEDS=$CACHE_DIR_FEEDS" >> $GITHUB_ENV
 
-          echo "::set-env name=SDK_HOME::$(mktemp -d)"
+          echo "SDK_HOME=$(mktemp -d)" >> $GITHUB_ENV
 
       - name: Download and Unzip SDK
         run: |


### PR DESCRIPTION
The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

fix it